### PR TITLE
Add total number of visits on the website to the Details screen

### DIFF
--- a/__tests__/__snapshots__/subcomponents.test.tsx.snap
+++ b/__tests__/__snapshots__/subcomponents.test.tsx.snap
@@ -40,6 +40,20 @@ exports[`DetailsView renders correctly according to snapshot 1`] = `
         Invalid Date
       </div>
     </div>
+    <div
+      className="details-view-table-row"
+    >
+      <div
+        className="details-view-table-label"
+      >
+        Total visits:
+      </div>
+      <div
+        className="details-view-table-value"
+      >
+        invalid-mocked-date
+      </div>
+    </div>
   </div>
   <div
     className="details-view-back-button"

--- a/__tests__/subcomponents.test.tsx
+++ b/__tests__/subcomponents.test.tsx
@@ -286,4 +286,16 @@ describe("DetailsView", () => {
         expect(timeSpentLabel?.textContent).toBe(`${translate("duration-header")}:`);
         expect(timeSpentValue?.textContent).toBe("0:04:03");
     });
+
+    it("contains the total number of visits with proper label and value matching storage state", async () => {
+        global._localStorage.setItem = jest.fn();
+        global._localStorage.getItem = (key: string) => {
+            return `[["${key}", "120"],["test", "24"]]`;
+        };
+        render(<DetailsView website="test" onBackButtonClick={() => undefined} />);
+        const totalNumberLabel = await screen.findByText(`${translate("details-view-number-of-visits")}:`);
+        const totalNumberValue = await screen.findByText("24");
+        expect(totalNumberLabel?.textContent).toBe(`${translate("details-view-number-of-visits")}:`);
+        expect(totalNumberValue?.textContent).toBe("24");
+    });
 });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,3 +1,4 @@
+import Database from "../app/src/engine/Database";
 import {
     getActiveTabDomainFromURL,
     getWebsiteIconObject,
@@ -7,6 +8,7 @@ import {
     optionEventValueToSortEnum,
     Sort,
     sortDataEntries,
+    storeVisitsNumber,
 } from "../app/src/popup/Utils";
 
 describe("getActiveTabDomainFromURL", () => {
@@ -73,6 +75,27 @@ describe("getWebsiteIconObject", () => {
             size: 20,
             src: "../resources/missing-website-favicon.png",
         });
+    });
+});
+
+describe("storeVisitsNumber", () => {
+    it("does not modify storage if domain is incorrect", () => {
+        const db = new Database();
+        const dbMockSpy = jest.spyOn(db, "readPreviousDomain");
+        storeVisitsNumber(null);
+        expect(dbMockSpy).not.toBeCalled();
+    });
+    it("reads previous domain from storage if domain is correct", () => {
+        global._localStorage.setItem = jest.fn();
+        const dbMockSpy = jest.spyOn(global._localStorage, "getItem");
+        storeVisitsNumber("some.website");
+        expect(dbMockSpy).toBeCalled();
+    });
+    it("saves given visits number to storage if domain is correct", () => {
+        global._localStorage.setItem = jest.fn();
+        const dbMockSpy = jest.spyOn(global._localStorage, "setItem");
+        storeVisitsNumber("some.website");
+        expect(dbMockSpy).toBeCalled();
     });
 });
 

--- a/app/src/engine/Background.ts
+++ b/app/src/engine/Background.ts
@@ -1,5 +1,5 @@
 import browser from "webextension-polyfill";
-import {calculateTimeSpentForDomain, getActiveTabDomainFromURL} from "../popup/Utils";
+import {calculateTimeSpentForDomain, getActiveTabDomainFromURL, storeVisitsNumber} from "../popup/Utils";
 import {storeTimeSpentSummary} from "../popup/Utils";
 import Database from "./Database";
 
@@ -11,7 +11,9 @@ browser.tabs.onActivated.addListener((activeInfo) => {
 
 browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (changeInfo.status == "complete") {
-        storeTimeSpentSummary(getActiveTabDomainFromURL(tab.url || "") || "");
+        const activeDomain = getActiveTabDomainFromURL(tab.url || "");
+        storeVisitsNumber(activeDomain);
+        storeTimeSpentSummary(activeDomain || "");
     }
 });
 

--- a/app/src/engine/Database.d.ts
+++ b/app/src/engine/Database.d.ts
@@ -14,4 +14,8 @@ export default class Database {
     writeLastVisited(domain: string, date: Date): void;
 
     readLastVisited(domain: string, onReturn: (date: Date) => void): void;
+
+    writeNumberOfVisits(domain: string, visitsNumber: number): void;
+
+    readNumberOfVisits(domain: string, onReturn: (visitsNumber: number) => void): void;
 }

--- a/app/src/engine/translations/de.json
+++ b/app/src/engine/translations/de.json
@@ -10,5 +10,6 @@
     "option-none": "Keine",
     "details-button-label": "Einzelheiten",
     "details-view-back-button-label": "Zurück",
-    "details-view-last-visited-label": "Letzter Besuch"
+    "details-view-last-visited-label": "Letzter Besuch",
+    "details-view-number-of-visits": "Gesamtbesuche"
 }

--- a/app/src/engine/translations/en.json
+++ b/app/src/engine/translations/en.json
@@ -10,5 +10,6 @@
     "option-none": "None",
     "details-button-label": "Details",
     "details-view-back-button-label": "Go back",
-    "details-view-last-visited-label": "Last visit"
+    "details-view-last-visited-label": "Last visit",
+    "details-view-number-of-visits": "Total visits"
 }

--- a/app/src/engine/translations/es.json
+++ b/app/src/engine/translations/es.json
@@ -10,5 +10,6 @@
     "option-none": "Ninguna",
     "details-button-label": "Detalles",
     "details-view-back-button-label": "Regresa",
-    "details-view-last-visited-label": "Última visita"
+    "details-view-last-visited-label": "Última visita",
+    "details-view-number-of-visits": "Visitas totales"
 }

--- a/app/src/engine/translations/fr.json
+++ b/app/src/engine/translations/fr.json
@@ -10,5 +10,6 @@
     "option-none": "Aucun",
     "details-button-label": "Détails",
     "details-view-back-button-label": "Retourner",
-    "details-view-last-visited-label": "Derniere visite"
+    "details-view-last-visited-label": "Derniere visite",
+    "details-view-number-of-visits": "Visites totales"
 }

--- a/app/src/engine/translations/pl.json
+++ b/app/src/engine/translations/pl.json
@@ -10,5 +10,6 @@
     "option-none": "Brak",
     "details-button-label": "Szczegóły",
     "details-view-back-button-label": "Wróć",
-    "details-view-last-visited-label": "Ostatnia wizyta"
+    "details-view-last-visited-label": "Ostatnia wizyta",
+    "details-view-number-of-visits": "Łącznie wizyt"
 }

--- a/app/src/popup/Utils.ts
+++ b/app/src/popup/Utils.ts
@@ -59,6 +59,20 @@ export function storeTimeSpentSummary(currentDomain: string) {
     });
 }
 
+export function storeVisitsNumber(domain: string | null) {
+    if (!domain) {
+        return;
+    }
+    const db = new Database();
+    db.readPreviousDomain((previousDomain) => {
+        if (previousDomain !== domain) {
+            db.readNumberOfVisits(domain, (numberOfVisits) => {
+                db.writeNumberOfVisits(domain, numberOfVisits + 1);
+            });
+        }
+    });
+}
+
 export const sortDataEntries = (data: Map<string, number>, sortMethod: Sort) => {
     return new Map(
         [...data].sort((entry1: [string, number], entry2: [string, number]) => {

--- a/app/src/popup/subcomponents/DetailsView.tsx
+++ b/app/src/popup/subcomponents/DetailsView.tsx
@@ -11,6 +11,7 @@ interface Props {
 const DetailsView = ({website, onBackButtonClick}: Props): React.JSX.Element => {
     const [lastVisited, setLastVisited] = useState<string>("...");
     const [timeSpent, setTimeSpent] = useState<string>("...");
+    const [numberOfVisits, setNumberOfVisits] = useState<number>(0);
     const db = new Database();
 
     useMemo(() => {
@@ -21,11 +22,13 @@ const DetailsView = ({website, onBackButtonClick}: Props): React.JSX.Element => 
             const timeInSeconds = result as number;
             setTimeSpent(`${getHours(timeInSeconds)}:${getMinutes(timeInSeconds)}:${getSeconds(timeInSeconds)}`);
         }, website);
+        db.readNumberOfVisits(website, (number) => setNumberOfVisits(number));
     }, []);
 
     const details = [
         {detail: translate("duration-header"), value: timeSpent},
         {detail: translate("details-view-last-visited-label"), value: lastVisited},
+        {detail: translate("details-view-number-of-visits"), value: numberOfVisits},
     ];
 
     return (

--- a/platforms/chromium/app/src/engine/Database.ts
+++ b/platforms/chromium/app/src/engine/Database.ts
@@ -176,6 +176,62 @@ class Database {
             onReturn(new Date());
         }
     }
+
+    writeNumberOfVisits(domain: string, visitsNumber: number): void {
+        if (!domain.length) {
+            return;
+        }
+        try {
+            browser.storage.local
+                .get("visitsNumber")
+                .then((visitsNumberObject) => {
+                    if (visitsNumberObject && Object.keys(visitsNumberObject).length) {
+                        const content = new Map<string, number>(Object.values(visitsNumberObject.visitsNumber));
+                        content.set(domain, visitsNumber);
+                        browser.storage.local
+                            .set(JSON.parse(`{"visitsNumber":${JSON.stringify(Array.from(content.entries()))}}`))
+                            .catch((error) => {
+                                console.error("browser.storage.local.set.error: ", error);
+                            });
+                    } else {
+                        browser.storage.local
+                            .set(
+                                JSON.parse(
+                                    `{"visitsNumber":${JSON.stringify(
+                                        Array.from(new Map<string, number>([[domain, visitsNumber]]).entries())
+                                    )}}`
+                                )
+                            )
+                            .catch((error) => {
+                                console.error("browser.storage.local.set.error: ", error);
+                            });
+                    }
+                })
+                .catch((error) => {
+                    console.error("writeNumberOfVisits.ERROR:", error);
+                });
+        } catch (exception) {
+            console.error(`ERROR: `, exception);
+        }
+    }
+
+    readNumberOfVisits(domain: string, onReturn: (visitsNumber: number) => void) {
+        if (domain.length === 0) {
+            return;
+        }
+        try {
+            browser.storage.local.get("visitsNumber").then((content) => {
+                const numberOfVisitsMap =
+                    content && Object.keys(content).length
+                        ? new Map<string, number>(Object.values(content.visitsNumber))
+                        : new Map<string, number>([]);
+                onReturn(numberOfVisitsMap.get(domain) || 0);
+            });
+        } catch (exception) {
+            console.error("ERROR: ", exception);
+            onReturn(0);
+        }
+    }
 }
 
 export default Database;

--- a/platforms/mozilla/app/src/engine/Database.ts
+++ b/platforms/mozilla/app/src/engine/Database.ts
@@ -133,6 +133,38 @@ class Database {
             console.error("writeLastVisited.error: ", error);
         }
     }
+
+    readNumberOfVisits(domain: string, onReturn: (visitsNumber: number) => void): void {
+        try {
+            const visitsNumberObject = this.storage.getItem("visitsNumber");
+            const visitsNumberMap =
+                visitsNumberObject && visitsNumberObject !== "{}"
+                    ? new Map<string, number>(JSON.parse(visitsNumberObject))
+                    : new Map<string, number>([]);
+            onReturn(visitsNumberMap.get(domain) || 0);
+        } catch (exception) {
+            console.error("readNumberOfVisits.error", exception);
+            onReturn(0);
+        }
+    }
+
+    writeNumberOfVisits(domain: string, visitsNumber: number): void {
+        try {
+            const visitsNumberObject = this.storage.getItem("visitsNumber");
+            if (visitsNumberObject && visitsNumberObject.length && visitsNumberObject !== "{}") {
+                const visitsNumberMap = new Map<string, number>(JSON.parse(visitsNumberObject));
+                visitsNumberMap.set(domain, visitsNumber);
+                this.storage.setItem("visitsNumber", JSON.stringify(Array.from(visitsNumberMap.entries())));
+            } else {
+                this.storage.setItem(
+                    "visitsNumber",
+                    JSON.stringify(Array.from(new Map<string, number>([[domain, visitsNumber]]).entries()))
+                );
+            }
+        } catch (error) {
+            console.error("writeNumberOfVisits.error: ", error);
+        }
+    }
 }
 
 export default Database;


### PR DESCRIPTION
This pull request adds the total number of visits to the `DetailsView`.

The total number of visits is increased for every website only when `onUpdated` happens, and only when the `previousDomain` is different than the one being updated.
This ensures that there are no false positive, for example when refresh happens, or navigation within the website happens.