### PR TITLE
Display average time spent on the website on the Details view

### DIFF
--- a/__tests__/__snapshots__/subcomponents.test.tsx.snap
+++ b/__tests__/__snapshots__/subcomponents.test.tsx.snap
@@ -66,6 +66,20 @@ exports[`DetailsView renders correctly according to snapshot 1`] = `
         invalid-mocked-date
       </div>
     </div>
+    <div
+      className="details-view-table-row"
+    >
+      <div
+        className="details-view-table-label"
+      >
+        Average daily:
+      </div>
+      <div
+        className="details-view-table-value"
+      >
+        NaN:00:NaN
+      </div>
+    </div>
   </div>
   <button
     className="button"

--- a/__tests__/subcomponents.test.tsx
+++ b/__tests__/subcomponents.test.tsx
@@ -290,9 +290,9 @@ describe("DetailsView", () => {
         };
         render(<DetailsView website="test" onBackButtonClick={() => undefined} />);
         const timeSpentLabel = await screen.findByText(`${translate("duration-header")}:`);
-        const timeSpentValue = await screen.findByText("0:04:03");
+        const timeSpentValue = await screen.findAllByText("0:04:03");
         expect(timeSpentLabel?.textContent).toBe(`${translate("duration-header")}:`);
-        expect(timeSpentValue?.textContent).toBe("0:04:03");
+        expect(timeSpentValue[0].textContent).toBe("0:04:03");
     });
 
     it("contains the total number of visits with proper label and value matching storage state", async () => {
@@ -305,5 +305,15 @@ describe("DetailsView", () => {
         const totalNumberValue = await screen.findByText("24");
         expect(totalNumberLabel?.textContent).toBe(`${translate("details-view-number-of-visits")}:`);
         expect(totalNumberValue?.textContent).toBe("24");
+    });
+
+    it("contains the average time spent daily on the website with proper values", async () => {
+        global._localStorage.setItem = jest.fn();
+        global._localStorage.getItem = (key: string) => {
+            return `[["${key}", "121"],["test", "245"]]`;
+        };
+        render(<DetailsView website="test" onBackButtonClick={() => undefined} />);
+        const avgTimeLabel = await screen.findByText(`${translate("details-view-average-daily-time")}:`);
+        expect(avgTimeLabel).toBeDefined();
     });
 });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,5 +1,6 @@
 import Database from "../app/src/engine/Database";
 import {
+    calculateAverageTimeSpentPerDay,
     getActiveTabDomainFromURL,
     getWebsiteIconObject,
     howManyHoursInSeconds,
@@ -159,6 +160,26 @@ describe("sortDataEntries", () => {
             ["test", 3],
         ]);
         expect(sortDataEntries(dataset, Sort.NameAscending)).toEqual(expected);
+    });
+});
+
+describe("calculateAverageTimeSpentPerDay", () => {
+    beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(1000 * 60 * 60 * 10 * 24);
+    });
+    it("returns 100 seconds if the first visit is today", () => {
+        const avgTime = calculateAverageTimeSpentPerDay(new Date(1000 * 60 * 60 * 10 * 24), 100);
+        expect(avgTime).toBe(100);
+    });
+
+    it("returns 200 seconds if the first visit is day after", () => {
+        const avgTime = calculateAverageTimeSpentPerDay(new Date(1000 * 60 * 60 * 9 * 24), 200);
+        expect(avgTime).toBe(200);
+    });
+
+    it("returns proper days if the first visit is several days before", () => {
+        const avgTime = calculateAverageTimeSpentPerDay(new Date(1000 * 60 * 60 * 2 * 24), 300);
+        expect(avgTime).toBe(300 / 8);
     });
 });
 

--- a/app/src/engine/Background.ts
+++ b/app/src/engine/Background.ts
@@ -1,5 +1,10 @@
 import browser from "webextension-polyfill";
-import {calculateTimeSpentForDomain, getActiveTabDomainFromURL, storeVisitsNumber} from "../popup/Utils";
+import {
+    calculateTimeSpentForDomain,
+    getActiveTabDomainFromURL,
+    storeFirstVisitDateForDomain,
+    storeVisitsNumber,
+} from "../popup/Utils";
 import {storeTimeSpentSummary} from "../popup/Utils";
 import Database from "./Database";
 
@@ -12,6 +17,7 @@ browser.tabs.onActivated.addListener((activeInfo) => {
 browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (changeInfo.status == "complete") {
         const activeDomain = getActiveTabDomainFromURL(tab.url || "");
+        storeFirstVisitDateForDomain(activeDomain || "");
         storeVisitsNumber(activeDomain);
         storeTimeSpentSummary(activeDomain || "");
     }

--- a/app/src/engine/Database.d.ts
+++ b/app/src/engine/Database.d.ts
@@ -18,4 +18,8 @@ export default class Database {
     writeNumberOfVisits(domain: string, visitsNumber: number): void;
 
     readNumberOfVisits(domain: string, onReturn: (visitsNumber: number) => void): void;
+
+    writeFirstVisitDate(domain: string, date: Date): void;
+
+    readFirstVisitDate(domain: string, onReturn: (firstVisitDate: Date) => void): void;
 }

--- a/app/src/engine/translations/de.json
+++ b/app/src/engine/translations/de.json
@@ -11,5 +11,6 @@
     "details-button-label": "Einzelheiten",
     "details-view-back-button-label": "Zurück",
     "details-view-last-visited-label": "Letzter Besuch",
-    "details-view-number-of-visits": "Gesamtbesuche"
+    "details-view-number-of-visits": "Gesamtbesuche",
+    "details-view-average-daily-time": "Durchschnittliche täglich"
 }

--- a/app/src/engine/translations/en.json
+++ b/app/src/engine/translations/en.json
@@ -11,5 +11,6 @@
     "details-button-label": "Details",
     "details-view-back-button-label": "Go back",
     "details-view-last-visited-label": "Last visit",
-    "details-view-number-of-visits": "Total visits"
+    "details-view-number-of-visits": "Total visits",
+    "details-view-average-daily-time": "Average daily"
 }

--- a/app/src/engine/translations/es.json
+++ b/app/src/engine/translations/es.json
@@ -11,5 +11,6 @@
     "details-button-label": "Detalles",
     "details-view-back-button-label": "Regresa",
     "details-view-last-visited-label": "Última visita",
-    "details-view-number-of-visits": "Visitas totales"
+    "details-view-number-of-visits": "Visitas totales",
+    "details-view-average-daily-time": "Promedio diario"
 }

--- a/app/src/engine/translations/fr.json
+++ b/app/src/engine/translations/fr.json
@@ -11,5 +11,6 @@
     "details-button-label": "Détails",
     "details-view-back-button-label": "Retourner",
     "details-view-last-visited-label": "Derniere visite",
-    "details-view-number-of-visits": "Visites totales"
+    "details-view-number-of-visits": "Visites totales",
+    "details-view-average-daily-time": "Moyenne quotidienne"
 }

--- a/app/src/engine/translations/pl.json
+++ b/app/src/engine/translations/pl.json
@@ -11,5 +11,6 @@
     "details-button-label": "Szczegóły",
     "details-view-back-button-label": "Wróć",
     "details-view-last-visited-label": "Ostatnia wizyta",
-    "details-view-number-of-visits": "Łącznie wizyt"
+    "details-view-number-of-visits": "Łącznie wizyt",
+    "details-view-average-daily-time": "Średnio dziennie"
 }

--- a/app/src/popup/Utils.ts
+++ b/app/src/popup/Utils.ts
@@ -73,6 +73,14 @@ export function storeVisitsNumber(domain: string | null) {
     });
 }
 
+export function storeFirstVisitDateForDomain(domain: string): void {
+    if (!domain) {
+        return;
+    }
+    const db = new Database();
+    db.writeFirstVisitDate(domain, new Date());
+}
+
 export const sortDataEntries = (data: Map<string, number>, sortMethod: Sort) => {
     return new Map(
         [...data].sort((entry1: [string, number], entry2: [string, number]) => {
@@ -99,6 +107,12 @@ export function calculateTimeSpentForDomain(domain: string) {
             db.writeTimeSpent(domain, Math.trunc(Math.abs(Date.now() - date.getTime()) / 1000) + (content as number));
         }, domain);
     });
+}
+
+export function calculateAverageTimeSpentPerDay(firstVisitDate: Date, totalVisitTime: number): number {
+    const millisecondsSinceFirstVisit = Date.now() - new Date(firstVisitDate).getTime();
+    const daysSinceFirstVisit = Math.max(1, Math.trunc(millisecondsSinceFirstVisit / (1000 * 60 * 60 * 24)));
+    return totalVisitTime / daysSinceFirstVisit;
 }
 
 export const howManyHoursInSeconds = (timeInSeconds: number): number => {

--- a/platforms/chromium/app/src/engine/Database.ts
+++ b/platforms/chromium/app/src/engine/Database.ts
@@ -232,6 +232,56 @@ class Database {
             onReturn(0);
         }
     }
+
+    writeFirstVisitDate(domain: string, date: Date): void {
+        if (domain?.length === 0) {
+            return;
+        }
+        try {
+            browser.storage.local
+                .get("firstVisit")
+                .then((content) => {
+                    if (!!content && Object.keys(content) && Object.keys(content)?.length) {
+                        const firstVisitMap = new Map<string, Date>(Object.values(content.firstVisit));
+                        if (!firstVisitMap.has(domain)) {
+                            firstVisitMap.set(domain, date);
+                            browser.storage.local.set(
+                                JSON.parse(`{"firstVisit":${JSON.stringify(Array.from(firstVisitMap.entries()))}}`)
+                            );
+                        }
+                    } else {
+                        browser.storage.local.set(
+                            JSON.parse(
+                                `{"firstVisit":${JSON.stringify(Array.from(new Map<string, Date>([]).entries()))}}`
+                            )
+                        );
+                    }
+                })
+                .catch((error) => {
+                    console.error("writeFirstVisitDate.browser.storage.local.get.error: ", error);
+                });
+        } catch (exception) {
+            console.error(`ERROR: `, exception);
+        }
+    }
+
+    readFirstVisitDate(domain: string, onReturn: (firstVisitDate: Date) => void): void {
+        if (domain.length === 0) {
+            return;
+        }
+        try {
+            browser.storage.local.get("firstVisit").then((content) => {
+                const firstVisitMap =
+                    content && Object.keys(content).length
+                        ? new Map<string, Date>(Object.values(content.firstVisit))
+                        : new Map<string, Date>([]);
+                onReturn(firstVisitMap.get(domain) || new Date());
+            });
+        } catch (exception) {
+            console.error("ERROR: ", exception);
+            onReturn(new Date());
+        }
+    }
 }
 
 export default Database;

--- a/platforms/mozilla/app/src/engine/Database.ts
+++ b/platforms/mozilla/app/src/engine/Database.ts
@@ -165,6 +165,40 @@ class Database {
             console.error("writeNumberOfVisits.error: ", error);
         }
     }
+
+    writeFirstVisitDate(domain: string, date: Date): void {
+        try {
+            const firstVisitObject = this.storage.getItem("firstVisit");
+            if (firstVisitObject && firstVisitObject.length && firstVisitObject !== "{}") {
+                const firstVisitMap = new Map<string, Date>(JSON.parse(firstVisitObject));
+                if (!firstVisitMap.has(domain)) {
+                    firstVisitMap.set(domain, date);
+                    this.storage.setItem("firstVisit", JSON.stringify(Array.from(firstVisitMap.entries())));
+                }
+            } else {
+                this.storage.setItem(
+                    "firstVisit",
+                    JSON.stringify(Array.from(new Map<string, Date>([[domain, date]]).entries()))
+                );
+            }
+        } catch (error) {
+            console.error("writeFirstVisitDate.error: ", error);
+        }
+    }
+
+    readFirstVisitDate(domain: string, onReturn: (firstVisitDate: Date) => void): void {
+        try {
+            const firstVisitObject = this.storage.getItem("firstVisit");
+            const firstVisitMap =
+                firstVisitObject && firstVisitObject !== "{}"
+                    ? new Map<string, Date>(JSON.parse(firstVisitObject))
+                    : new Map<string, Date>([]);
+            onReturn(firstVisitMap.get(domain) || new Date());
+        } catch (exception) {
+            console.error("readNumberOfVisits.error", exception);
+            onReturn(new Date());
+        }
+    }
 }
 
 export default Database;


### PR DESCRIPTION
This pull request closes #9 
It adds the average time spent on the website to the DetailsView screen.

The average time is calculated as
`total time spent on the website` / `total days since last visit`.
It is designed to treat the same day and day after as `1` for total days since last visit.